### PR TITLE
Cache return null if no value is found

### DIFF
--- a/lib/src/nyxx/internal/Cache.dart
+++ b/lib/src/nyxx/internal/Cache.dart
@@ -12,7 +12,7 @@ abstract class Cache<T, S> implements Disposable {
   Iterable<T> get keys => _cache.keys;
 
   /// Find one element in cache
-  S findOne(bool predicate(S item)) => values.firstWhere(predicate);
+  S findOne(bool predicate(S item)) => values.firstWhere(predicate, orElse: () => null);
 
   /// Find matching items based of [predicate]
   Iterable<S> find(bool predicate(S item)) => values.where(predicate);


### PR DESCRIPTION
In Dart `firstWhere` doesn't return null if no value was found, it throws a StateError instead unless `orElse` is specified.
This causes an error when trying to send a DM to a user because the channel isn't in the Cache. See https://github.com/l7ssha/nyxx/blob/development/lib/src/nyxx/objects/user/User.dart#L59

Fixes #36 