### PR TITLE
Fix #53 - CommandFramework improperly responds when a stream is passed

### DIFF
--- a/nyxx.commands/lib/src/CommandsFramework.dart
+++ b/nyxx.commands/lib/src/CommandsFramework.dart
@@ -45,10 +45,8 @@ class CommandsFramework {
         stream = client.onSelfMention;
       } else if (stream == null && prefix != null)
         stream = client.onMessageReceived;
-      else {
-        _logger.severe("CANNOT CREATE FRAMEWORK WITHOUT PREFIX");
-        exit(1);
-      }
+      else if (stream != null && prefix == null)
+        prefix = client.self.mention;
 
       stream.listen((MessageEvent e) {
         if (ignoreBots && e.message.author.bot) return;

--- a/nyxx.commands/lib/src/CommandsFramework.dart
+++ b/nyxx.commands/lib/src/CommandsFramework.dart
@@ -43,10 +43,11 @@ class CommandsFramework {
       if (prefix == null && stream == null) {
         prefix = client.self.mention;
         stream = client.onSelfMention;
-      } else if (stream == null && prefix != null)
+      } else if (stream == null && prefix != null) {
         stream = client.onMessageReceived;
-      else if (stream != null && prefix == null)
+      } else if (stream != null && prefix == null) {
         prefix = client.self.mention;
+      }
 
       stream.listen((MessageEvent e) {
         if (ignoreBots && e.message.author.bot) return;


### PR DESCRIPTION
Removes the final else & replaces it with the option to define a stream but not a prefix. By also removing the final else, the option can be made to pass both a prefix and a stream to the constructor and not have the bot shut down instantly.