### PR TITLE
Enhancing the potential usage of CommandsFramework by making dispatch() public.

### DIFF
--- a/nyxx.commands/lib/src/CommandsFramework.dart
+++ b/nyxx.commands/lib/src/CommandsFramework.dart
@@ -45,11 +45,12 @@ class CommandsFramework {
   }
 
   ///Listens to messages sent that contain the prefix and triggers the dispatching of the command.
-  void _streamListener({Stream<MessageEvent> stream}) async {
+  void _streamListener({Stream<MessageEvent>? stream}) async {
     if (!client.ready) {
       //Allows to start listening if onReady has already been recieved
       await client.onReady.first;
     }
+
     if (prefix == null && stream == null) {
       prefix = client.self.mention;
       stream = client.onSelfMention;
@@ -59,9 +60,9 @@ class CommandsFramework {
       prefix = client.self.mention;
     }
 
-      stream!.listen((MessageEvent e) {
-        if (ignoreBots && e.message?.author != null && e.message!.author!.bot) return;
-        if (!e.message!.content.startsWith(prefix)) return;
+    stream!.listen((MessageEvent e) {
+      if (ignoreBots && e.message?.author != null && e.message!.author!.bot) return;
+      if (!e.message!.content.startsWith(prefix)) return;
 
       Future(() => dispatch(e));
     });
@@ -168,12 +169,17 @@ class CommandsFramework {
   }
 
   /// Dispatches onMessage event to framework.
-  Future _dispatch(MessageEvent e) async {
+  Future dispatch(MessageEvent e, {String? prefix}) async {
     if(e.message == null) {
       return;
     }
 
-    var cmdWithoutPrefix = e.message!.content.replaceFirst(prefix, "").trim();
+    String cmdWithoutPrefix;
+    if (prefix == null) {
+      cmdWithoutPrefix = e.message!.content.replaceFirst(this.prefix, "").trim();
+    } else {
+      cmdWithoutPrefix = e.message!.content.replaceFirst(prefix, "").trim();
+    }
 
     _CommandMetadata matchedMeta;
     try {

--- a/nyxx.commands/lib/src/CommandsFramework.dart
+++ b/nyxx.commands/lib/src/CommandsFramework.dart
@@ -46,7 +46,7 @@ class CommandsFramework {
 
   ///Listens to messages sent that contain the prefix and triggers the dispatching of the command.
   void _streamListener({Stream<MessageEvent> stream}) async {
-    if(!client.ready) {
+    if (!client.ready) {
       //Allows to start listening if onReady has already been recieved
       await client.onReady.first;
     }
@@ -168,11 +168,11 @@ class CommandsFramework {
   }
 
   /// Dispatches onMessage event to framework.
-  /// 
+  ///
   /// Optionally takes a [prefix] to remove from the message recieved from MessageEvent [e].
   Future dispatch(MessageEvent e, {String prefix}) async {
     var cmdWithoutPrefix;
-    if(prefix == null) {
+    if (prefix == null) {
       cmdWithoutPrefix = e.message.content.replaceFirst(this.prefix, "").trim();
     } else {
       cmdWithoutPrefix = e.message.content.replaceFirst(prefix, "").trim();


### PR DESCRIPTION
Most of my reasoning behind the changes are listed in the ~~mile long~~ description on commit https://github.com/l7ssha/nyxx/commit/de4e580c9aa7ebb828b22bd9f6f3a2c2d8329fad. (For clarity; a guild's stream is a stream that only contains message events for that guild)

The basic gist of it is it'll make it easier for users to make their own handler that triggers commands but still gets the features that CommandsFramework offers (command discovery, the metadata tags, etc...).

A potential flaw in this I see is that if a user defines a prefix but then tries to also manually dispatch events, the bot would still respond to the defined prefix when CommandsFramework is setup (assuming a stream isn't given). But if the user didn't define a prefix, the bot would use the mention which would allow for a custom prefix passed to dispatch and a constant trigger method that would be out of the way of conflicts with other bots.

I dunno if this is exactly a proper idea for the way the library works.

