### PR TITLE
Fix DMChannel recognition/creation

### DIFF
--- a/nyxx/lib/src/core/channel/dm/DMChannel.dart
+++ b/nyxx/lib/src/core/channel/dm/DMChannel.dart
@@ -6,7 +6,7 @@ class DMChannel extends MessageChannel {
   late User recipient;
 
   DMChannel._new(Map<String, dynamic> raw, Nyxx client)
-      : super._new(raw, 4, client) {
+      : super._new(raw, 1, client) {
     if (raw['recipients'] != null) {
       this.recipient = User._new(raw['recipients'][0] as Map<String, dynamic>, client);
     } else {


### PR DESCRIPTION
Before it would be recognized and sent to the user as a "GUILD_CATEGORY". Now it'll actually be a DM channel as per https://discord.com/developers/docs/resources/channel