### PR TITLE
Patch type confliction for pinned message channel

### DIFF
--- a/nyxx/lib/src/events/ChannelEvents.dart
+++ b/nyxx/lib/src/events/ChannelEvents.dart
@@ -41,7 +41,7 @@ class ChannelDeleteEvent {
 /// Fired when channel"s pinned messages are updated
 class ChannelPinsUpdateEvent {
   /// Channel where pins were updated
-  CachelessTextChannel? channel;
+  CacheTextChannel? channel;
 
   /// ID of channel pins were updated
   late final Snowflake channelId;
@@ -57,7 +57,7 @@ class ChannelPinsUpdateEvent {
       this.lastPingTimestamp = DateTime.parse(raw["d"]["last_pin_timestamp"] as String);
     }
 
-    this.channel = client.channels[Snowflake(raw["d"]["channel_id"])] as CachelessTextChannel?;
+    this.channel = client.channels[Snowflake(raw["d"]["channel_id"])] as CacheTextChannel?;
 
     if (raw["d"]["guild_id"] != null) {
       this.guildId = Snowflake(raw["d"]["guild_id"]);


### PR DESCRIPTION
client.channels[] returns a CacheTextChannel rather than CachelessTextChannel as expected before the change.
All this does is change the type so a type confliction error is not raised