### PR TITLE
Use entity.isEntityName instead of entity.name

### DIFF
--- a/nyxx.commander/lib/src/utils.dart
+++ b/nyxx.commander/lib/src/utils.dart
@@ -12,7 +12,7 @@ extension _CommandMatcher on Iterable<CommandEntity> {
         }
       }
 
-      if(entity is CommandGroup && entity.name == messageParts.first) {
+      if(entity is CommandGroup && entity.isEntityName(messageParts.first)) {
         if (messageParts.length == 1 && entity.defaultHandler != null) {
           return entity.defaultHandler;
         } else if (messageParts.length == 1 && entity.defaultHandler == null) {
@@ -26,7 +26,7 @@ extension _CommandMatcher on Iterable<CommandEntity> {
         }
       }
 
-      if(entity is CommandHandler && entity.name == messageParts.first) {
+      if(entity is CommandHandler && entity.isEntityName(messageParts.first)) {
         return entity;
       }
     }


### PR DESCRIPTION
Currently, aliases don't work because messageParts.first is only checked against entity.name.
Using entity.isEntityName fixes this.