### PR TITLE
Match final command name using RegEx to fix argument extraction

### DIFF
--- a/nyxx.commander/lib/src/CommandHandler.dart
+++ b/nyxx.commander/lib/src/CommandHandler.dart
@@ -18,20 +18,20 @@ abstract class CommandEntity {
   /// Parent of entity
   CommandEntity? get parent;
 
-  /// Returns true if provided String [str] is entity name or alias
-  bool isEntityName(String str) =>
-      str == this.name || this.aliases.any((element) => element == str);
+  /// A list of valid command names
+  List<String> get commandNames => [this.name, ...this.aliases];
 
-  /// Full qualified command name with its parents names
-  String getFullCommandName() {
-    var commandName = this.name;
-
-    for(var e = this.parent; e != null; e = e.parent) {
-      commandName = "${e.name} $commandName";
+  /// RegEx matching the fully qualified command name with its parents and all aliases
+  String getFullCommandMatch() {
+    var parentMatch = "";
+    if (parent != null) {
+      parentMatch = "${parent!.getFullCommandMatch()} ";
     }
-
-    return commandName.trim();
+    return '$parentMatch(${this.commandNames.join('|')})';
   }
+
+  /// Returns true if provided String [str] is entity name or alias
+  bool isEntityName(String str) => commandNames.contains(str);
 }
 
 /// Creates command group. Pass a [name] to crated command and commands added

--- a/nyxx.commander/lib/src/Commander.dart
+++ b/nyxx.commander/lib/src/Commander.dart
@@ -105,15 +105,9 @@ class Commander with ICommandRegistrable {
     // Example: (?<finalCommand>(quote|q) (remove|rm))
     // This will match the command `quote remove`, `q remove`, `quote rm` and `q rm`
 
-    final match = RegExp("(?<finalCommand>${matchingCommand.getFullCommandMatch()})").firstMatch(
-      event.message.content,
-    );
+    final match = RegExp("(?<finalCommand>${matchingCommand.getFullCommandMatch()})").firstMatch(event.message.content);
 
     final finalCommand = match?.namedGroup("finalCommand");
-
-    if (finalCommand == null) {
-      return;
-    }
 
     // construct commandcontext
     final context = CommandContext._new(

--- a/nyxx.commander/lib/src/Commander.dart
+++ b/nyxx.commander/lib/src/Commander.dart
@@ -102,8 +102,8 @@ class Commander with ICommandRegistrable {
 
     // Builds a RegEx that matches the full command including their parents and all possible
     // aliases of the final command entity and their parents.
-    // Example: (?<finalCommand>(quote|quotes) (remove|rm))
-    // This will match the command `quote remove`, `quotes remove`, `quote rm` and `quotes rm`
+    // Example: (?<finalCommand>(quote|q) (remove|rm))
+    // This will match the command `quote remove`, `q remove`, `quote rm` and `q rm`
 
     final match = RegExp("(?<finalCommand>${matchingCommand.getFullCommandMatch()})").firstMatch(
       event.message.content,

--- a/nyxx.commander/lib/src/Commander.dart
+++ b/nyxx.commander/lib/src/Commander.dart
@@ -117,11 +117,12 @@ class Commander with ICommandRegistrable {
 
     // construct commandcontext
     final context = CommandContext._new(
-        event.message.channel.getFromCache()!,
-        event.message.author,
-        event.message is GuildMessage ? (event.message as GuildMessage).guild.getFromCache()! : null,
-        event.message,
-        "$prefix$finalCommand");
+      event.message.channel.getFromCache()!,
+      event.message.author,
+      event.message is GuildMessage ? (event.message as GuildMessage).guild.getFromCache()! : null,
+      event.message,
+      "$prefix$finalCommand",
+    );
 
     // Invoke before handler for commands
     if (!(await _invokeBeforeHandler(matchingCommand, context))) {

--- a/nyxx.commander/lib/src/Commander.dart
+++ b/nyxx.commander/lib/src/Commander.dart
@@ -142,7 +142,7 @@ class Commander with ICommandRegistrable {
     }
 
     // execute logger callback
-    _loggerHandlerFunction(context, finalCommand, this._logger);
+    _loggerHandlerFunction(context, finalCommand!, this._logger);
 
     // invoke after handler of command
     await _invokeAfterHandler(matchingCommand, context);

--- a/nyxx.commander/lib/src/utils.dart
+++ b/nyxx.commander/lib/src/utils.dart
@@ -1,16 +1,5 @@
 part of nyxx_commander;
 
-String _getFullCommandFromMessage(CommandHandler commandHandler, List<String> messageParts) {
-  var iterator = 1;
-
-  for(var e = commandHandler.parent; e != null; e = e.parent) {
-    iterator++;
-  }
-
-  messageParts.removeRange(iterator, messageParts.length);
-  return messageParts.join(" ");
-}
-
 // TODO: FIX. I think that is just awful but is does its job
 extension _CommandMatcher on Iterable<CommandEntity> {
   CommandEntity? _findMatchingCommand(Iterable<String> messageParts) {


### PR DESCRIPTION
The recent commit to fix the initial issue #111 wasn't working for me and introduced all sorts of problems with getting command arguments. This PR is trying to fix the issue once and for all. 

I have introduced a new getter and replaced getFullCommandName() with getFullCommandMatch().
This function returns a RegEx match which includes all possible command names.
By using RegEx, we are no longer in the dark on what the final command is and CommandContext.getArguments() is going to remove the actual command accordingly and grab only the arguments.

An example for the scenario would be a CommandGroup with name `quote` and and alias of `q`.
This CommandGroup has several subcommands, one of which is `remove` with an alias of `rm`.

The messages that can trigger this command are the following:

- quote remove
- q remove
- quote rm
- q rm

Using isEntityName, we're already matching the correct name for command execution, but we were still passing an incorrect command name to the CommandContext, which would result in the actual command not being replaced and the argument list containing parts of the command.