### PR TITLE
Fixed JSON encode error on CommandArg

### DIFF
--- a/nyxx.interactions/lib/src/models/InteractionOption.dart
+++ b/nyxx.interactions/lib/src/models/InteractionOption.dart
@@ -23,7 +23,7 @@ class InteractionOption {
     this.type = CommandArgType(raw["type"] as int);
 
     if (raw["options"] != null) {
-      this.args = (raw["options"] as List<Map<String, dynamic>>).map((e) => InteractionOption._new(e));
+      this.args = (raw["options"] as List<dynamic>).map((e) => InteractionOption._new(e));
     }
 
     if (raw["choices"] != null) {

--- a/nyxx.interactions/lib/src/models/commandArgs/CommandArg.dart
+++ b/nyxx.interactions/lib/src/models/commandArgs/CommandArg.dart
@@ -66,7 +66,7 @@ class CommandArg implements Builder {
       "description": this.description,
       "default": this.defaultArg,
       "required": this.required,
-      if (this.choices != null) "choices": this.choices!.map((e) => e._build()),
-      if (this.options != null) "options": this.options!.map((e) => e._build())
+      if (this.choices != null) "choices": this.choices!.map((e) => e._build()).toList(),
+      if (this.options != null) "options": this.options!.map((e) => e._build()).toList()
     };
 }


### PR DESCRIPTION
# Description

`Converting object to an encodable object failed: Instance of 'MappedListIterable<CommandArg, Map<String, dynamic>>'`

This error was occurring when adding the list of options or choices to a `CommandArg` as the JSON encoding was reading it as a `MappedListIterable` instead of a regular `List`. This fixes the issue and relevant options and choices now appear on Discord

## Type of change
Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] Ran `dartfmt -w -l 120 --fix .`
- [x] Ran `dartanalyzer --options analysis_options.yaml .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works