### PR TITLE
Resolve URI.replace syntax error causing queryParameters to not be added.

### DIFF
--- a/nyxx/lib/src/internal/http/HttpRequest.dart
+++ b/nyxx/lib/src/internal/http/HttpRequest.dart
@@ -34,7 +34,7 @@ class BasicRequest extends _HttpRequest {
 
   @override
   Future<http.StreamedResponse> _execute() async {
-    final request = http.Request(this.method, this.uri..replace(queryParameters: queryParams))
+    final request = http.Request(this.method, this.uri.replace(queryParameters: queryParams))
       ..headers.addAll(_genHeaders());
 
     if (this.body != null && this.method != "GET") {

--- a/nyxx/lib/src/internal/http/HttpRequest.dart
+++ b/nyxx/lib/src/internal/http/HttpRequest.dart
@@ -69,7 +69,7 @@ class MultipartRequest extends _HttpRequest {
 
   @override
   Future<http.StreamedResponse> _execute() {
-    final request = http.MultipartRequest(this.method, this.uri..replace(queryParameters: queryParams))
+    final request = http.MultipartRequest(this.method, this.uri.replace(queryParameters: queryParams))
       ..headers.addAll(_genHeaders());
 
     for (final file in this.files) {


### PR DESCRIPTION
# Description

Changes the cascade operator used in `this.uri..replace(...` to a property modifier `this.uri.replace`. Prior to this change, the URI would not be updated with the queryParameters, causing issues with endpoints that utilize these parameters such as the REST Search Guild Members endpoint - ultimately fully resolving #102.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [X] Ran `dartanalyzer --options analysis_options.yaml .`
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
