### PR TITLE
Add Guild#fetchRoles

### DIFF
--- a/nyxx/lib/src/core/guild/Guild.dart
+++ b/nyxx/lib/src/core/guild/Guild.dart
@@ -287,6 +287,11 @@ class Guild extends SnowflakeEntity {
   Future<GuildSticker> fetchSticker(Snowflake id) =>
       client.httpEndpoints.fetchGuildSticker(this.id, id);
 
+  /// Fetches all roles that are in the server.
+  /// To get a single file use .firstWhere()
+  Stream<Role> fetchRoles() =>
+      client.httpEndpoints.fetchGuildRoles(this.id);
+
   /// Creates sticker in current guild
   Future<GuildSticker> createSticker(StickerBuilder builder) =>
       client.httpEndpoints.createGuildSticker(this.id, builder);

--- a/nyxx/lib/src/core/guild/Guild.dart
+++ b/nyxx/lib/src/core/guild/Guild.dart
@@ -288,7 +288,6 @@ class Guild extends SnowflakeEntity {
       client.httpEndpoints.fetchGuildSticker(this.id, id);
 
   /// Fetches all roles that are in the server.
-  /// To get a single file use .firstWhere()
   Stream<Role> fetchRoles() =>
       client.httpEndpoints.fetchGuildRoles(this.id);
 


### PR DESCRIPTION
Add ability to fetch a guilds roles, no endpoint to fetch single role. Could be added as a method but leaving up to user to sort on the stream. Sorts issue #152 
