### PR TITLE
Migrate separate arguments with file format to AttachmentBuilder

### DIFF
--- a/nyxx/lib/src/core/channel/guild/TextGuildChannel.dart
+++ b/nyxx/lib/src/core/channel/guild/TextGuildChannel.dart
@@ -43,8 +43,8 @@ class TextGuildChannel extends GuildChannel implements TextChannel, Mentionable 
   /// ```
   /// final webhook = await channnel.createWebhook("!a Send nudes kek6407");
   /// ```
-  Future<Webhook> createWebhook(String name, {File? avatarFile, String? auditReason}) =>
-      client.httpEndpoints.createWebhook(this.id, name, avatarFile: avatarFile, auditReason: auditReason);
+  Future<Webhook> createWebhook(String name, {AttachmentBuilder? avatarAttachment, String? auditReason}) =>
+      client.httpEndpoints.createWebhook(this.id, name, avatarAttachment: avatarAttachment, auditReason: auditReason);
 
   /// Returns pinned [Message]s for channel.
   Stream<Message> getPinnedMessages() =>

--- a/nyxx/lib/src/core/guild/ClientUser.dart
+++ b/nyxx/lib/src/core/guild/ClientUser.dart
@@ -29,6 +29,6 @@ class ClientUser extends User {
   }
 
   /// Edits current user. This changes user's username - not per guild nickname.
-  Future<User> edit({String? username, File? avatarFile, List<int>? avatarBytes, String? encodedAvatar, String? encodedExtension}) =>
-      client.httpEndpoints.editSelfUser(username: username, avatarFile: avatarFile, avatarBytes: avatarBytes, encodedAvatar: encodedAvatar, encodedExtension: encodedExtension);
+  Future<User> edit({String? username, AttachmentBuilder? avatarAttachment}) =>
+      client.httpEndpoints.editSelfUser(username: username, avatarAttachment: avatarAttachment);
 }

--- a/nyxx/lib/src/core/guild/Guild.dart
+++ b/nyxx/lib/src/core/guild/Guild.dart
@@ -306,8 +306,8 @@ class Guild extends SnowflakeEntity {
   /// var emojiFile = new File("weed.png");
   /// vare emoji = await guild.createEmoji("weed, image: emojiFile");
   /// ```
-  Future<GuildEmoji> createEmoji(String name, {List<SnowflakeEntity>? roles, File? imageFile, List<int>? imageBytes, String? encodedImage, String? encodedExtension}) =>
-      client.httpEndpoints.createEmoji(this.id, name, roles: roles, imageFile: imageFile, imageBytes: imageBytes, encodedImage: encodedImage, encodedExtension: encodedExtension);
+  Future<GuildEmoji> createEmoji(String name, {List<SnowflakeEntity>? roles, AttachmentBuilder? emojiAttachment}) =>
+      client.httpEndpoints.createEmoji(this.id, name, roles: roles, emojiAttachment: emojiAttachment);
 
   /// Returns [int] indicating the number of members that would be removed in a prune operation.
   Future<int> pruneCount(int days, {Iterable<Snowflake>? includeRoles}) =>

--- a/nyxx/lib/src/core/guild/Webhook.dart
+++ b/nyxx/lib/src/core/guild/Webhook.dart
@@ -9,11 +9,12 @@ class WebhookType extends IEnum<int> {
   /// Channel Follower Webhooks are internal webhooks used with Channel Following to post new messages into channels
   static const WebhookType channelFollower = WebhookType._create(2);
 
-  const WebhookType._create(int? value) : super(value ?? 0);
+  /// Creates instance of [WebhookType] from [value]. Default value is 0
   WebhookType.from(int? value) : super(value ?? 0);
+  const WebhookType._create(int? value) : super(value ?? 0);
 
   @override
-  bool operator ==(other) {
+  bool operator ==(dynamic other) {
     if (other is int) {
       return other == _value;
     }
@@ -122,9 +123,9 @@ class Webhook extends SnowflakeEntity implements IMessageAuthor {
       client.httpEndpoints.userAvatarURL(this.id, this.avatarHash, 0, format: format, size: size);
 
   /// Edits the webhook.
-  Future<Webhook> edit({String? name, SnowflakeEntity? channel, File? avatarFile, List<int>? avatarBytes, String? encodedAvatar, String? encodedExtension, String? auditReason}) =>
+  Future<Webhook> edit({String? name, SnowflakeEntity? channel, AttachmentBuilder? avatarAttachment, String? auditReason}) =>
     client.httpEndpoints.editWebhook(this.id, token: this.token, name: name,
-        channel: channel, avatarFile: avatarFile, avatarBytes: avatarBytes, encodedAvatar: encodedAvatar, encodedExtension: encodedExtension, auditReason: auditReason);
+        channel: channel, avatarAttachment: avatarAttachment, auditReason: auditReason);
 
   /// Deletes the webhook.
   Future<void> delete({String? auditReason}) =>

--- a/nyxx/lib/src/utils/builders/AttachmentBuilder.dart
+++ b/nyxx/lib/src/utils/builders/AttachmentBuilder.dart
@@ -24,7 +24,7 @@ class AttachmentBuilder {
 
   /// Create attachment from specified file instance. Name will be automatically extracted from path if no name provided.
   factory AttachmentBuilder.file(File file, {String? name, bool? spoiler}) {
-    final  bytes = file.readAsBytesSync();
+    final bytes = file.readAsBytesSync();
     final fileName = name ?? path_utils.basename(file.path);
 
     return AttachmentBuilder._new(bytes, fileName, spoiler);
@@ -34,7 +34,15 @@ class AttachmentBuilder {
   factory AttachmentBuilder.bytes(List<int> bytes, String name, {bool? spoiler}) =>
     AttachmentBuilder._new(bytes, name, spoiler);
 
-  // creates instance of MultipartFile
-  http.MultipartFile _asMultipartFile() =>
+  /// creates instance of MultipartFile from attachment
+  http.MultipartFile getMultipartFile() =>
       http.MultipartFile(_name, Stream.value(_bytes), _bytes.length, filename: _name);
+
+  /// Returns attachment encoded in Data URI scheme format
+  /// See: https://discord.com/developers/docs/reference#image-data
+  String getBase64() {
+    final encodedData = base64Encode(_bytes);
+    final extension = path_utils.extension(_name);
+    return "data:image/$extension;base64,$encodedData";
+  }
 }

--- a/nyxx/lib/src/utils/builders/MessageBuilder.dart
+++ b/nyxx/lib/src/utils/builders/MessageBuilder.dart
@@ -53,6 +53,11 @@ class MessageBuilder extends BuilderWithClient {
       MessageBuilder()
         ..embeds = [embed];
 
+  /// Creates [MessageBuilder] with only specified files
+  factory MessageBuilder.files(List<AttachmentBuilder> files) =>
+      MessageBuilder()
+        ..files = files;
+
   /// Creates [MessageBuilder] from [Message].
   /// Copies content, tts and first embed of target [message]
   factory MessageBuilder.fromMessage(Message message) => MessageBuilder()
@@ -116,7 +121,9 @@ class MessageBuilder extends BuilderWithClient {
 
   /// Add attachment
   void addAttachment(AttachmentBuilder attachment) {
-    if (this.files == null) this.files = [];
+    if (this.files == null) {
+      this.files = [];
+    }
 
     this.files!.add(attachment);
   }

--- a/nyxx/lib/src/utils/utils.dart
+++ b/nyxx/lib/src/utils/utils.dart
@@ -10,21 +10,4 @@ class Utils {
       yield list.sublist(i, size > len ? len : size);
     }
   }
-
-  /// Returns String with base64 encoded image data for API upload
-  static String? getBase64UploadString({File? file, List<int>? fileBytes, String? base64EncodedFile, String? fileExtension}) {
-    String base64Encoded;
-    if (file != null) {
-      base64Encoded = base64Encode(file.readAsBytesSync());
-    } else if (fileBytes != null) {
-      base64Encoded = base64Encode(fileBytes);
-    } else if (base64EncodedFile != null) {
-      base64Encoded = base64EncodedFile;
-    } else {
-      return null;
-    }
-
-    final extension = file != null ? path_utils.extension(file.path).replaceAll(".", "") : fileExtension;
-    return "data:image/$extension;base64,$base64Encoded";
-  }
 }

--- a/nyxx/test/unit.dart
+++ b/nyxx/test/unit.dart
@@ -161,15 +161,15 @@ void main() {
 
   group("Generic utils", () {
     test("Utils.getBase64UploadString returns valid string", () {
-      final kittyFile = File("./test/kitty.webp");
+      const path = "./test/kitty.webp";
       const extension = "webp";
 
+      final kittyFile = File(path);
       final encodedKitty = base64Encode(kittyFile.readAsBytesSync());
 
       final expectedStringFile = "data:image/$extension;base64,$encodedKitty";
-      expect(Utils.getBase64UploadString(file: kittyFile, fileExtension: extension), expectedStringFile);
-      expect(Utils.getBase64UploadString(fileBytes: kittyFile.readAsBytesSync(), fileExtension: extension), expectedStringFile);
-      expect(Utils.getBase64UploadString(base64EncodedFile: encodedKitty, fileExtension: extension), expectedStringFile);
+      expect(AttachmentBuilder.file(kittyFile), expectedStringFile);
+      expect(AttachmentBuilder.bytes(kittyFile.readAsBytesSync(), path), expectedStringFile);
     }, skip: "Skipped for now because of problems with required path to file");
 
     test("Utils.chunk returns valid chunks", () async {


### PR DESCRIPTION
# Description

Migrates methods with arguments for separate file format (bytes, path, base64...) to single arugment of AttachmentBuilder to simplify and uniform file upload to discord

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] Ran `dartanalyzer --options analysis_options.yaml .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
