### PR TITLE
fix(Interactions): use case-insensitive name comparison in _registerC…

### DIFF
--- a/nyxx_interactions/lib/src/Interactions.dart
+++ b/nyxx_interactions/lib/src/Interactions.dart
@@ -230,7 +230,8 @@ class Interactions {
 
   void _registerCommandHandlers(List<SlashCommand> registeredSlashCommands, Iterable<SlashCommandBuilder> builders) {
     for(final registeredCommand in registeredSlashCommands) {
-      final matchingBuilder = builders.firstWhere((element) => element.name.toLowerCase() == registeredCommand.name);
+      final matchingBuilder =
+          builders.firstWhere((element) => element.name.toLowerCase() == registeredCommand.name.toLowerCase());
       this._assignCommandToHandler(matchingBuilder, registeredCommand);
 
       this._commands.add(registeredCommand);


### PR DESCRIPTION
…ommandHandlers

# Description

This fixes an oversight in `_registerCommandHandlers`, which was converting the builder name to lower case and checking against the registered command in source case. However, context menu commands can have names of mixed case. This PR changes this to convert both sides to lower case before comparing. Alternatively, command case could be validated upon registering a command -- slash commands with upper-case characters would throw an exception, and then a case-sensitive comparison could be used.

This resolves the following error which could be triggered by registering a context menu command with a non-lower-case name:
```dart
Bad state: No element
#0      ListMixin.firstWhere (dart:collection/list.dart:167:5)
#1      Interactions._registerCommandHandlers (package:nyxx_interactions/src/Interactions.dart:233:40)
#2      Interactions.sync (package:nyxx_interactions/src/Interactions.dart:134:12)
<asynchronous suspension>
#3      Interactions.syncOnReady.<anonymous closure> (package:nyxx_interactions/src/Interactions.dart:105:7)
<asynchronous suspension>
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dartanalyzer --options analysis_options.yaml .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
