### PR TITLE
Improve error handling

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -216,9 +216,16 @@ abstract class Nyxx {
     }, clientOptions.plugins);
   }
 
+  /// A future that completes when this client closes.
+  ///
+  /// If this client closes because of an error, this future will complete with that error.
+  Future<void> get done => _doneCompleter.future;
+
   /// Close this client and any underlying resources.
   ///
   /// The client should not be used after this is called and unexpected behavior may occur.
+  ///
+  /// Returns the same future as [done].
   Future<void> close() {
     logger.info('Closing client');
 

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -366,7 +366,9 @@ class NyxxGateway extends Nyxx with ManagerMixin, EventMixin implements NyxxRest
 
   @override
   Future<void> _doClose() async {
-    await gateway.close();
-    await httpHandler.close();
+    await [
+      gateway.close(),
+      httpHandler.close(),
+    ].wait;
   }
 }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -24,7 +24,7 @@ import 'package:oauth2/oauth2.dart';
 import 'package:runtime_type/runtime_type.dart';
 
 /// A helper function to nest and execute calls to plugin connect methods.
-Future<T> _doConnect<T extends Nyxx>(ApiOptions apiOptions, ClientOptions clientOptions, Future<T> Function() connect, List<NyxxPlugin> plugins) {
+Future<T> _pluginConnect<T extends Nyxx>(ApiOptions apiOptions, ClientOptions clientOptions, Future<T> Function() connect, List<NyxxPlugin> plugins) {
   final actualClientType = RuntimeType<T>();
 
   for (final plugin in plugins) {
@@ -45,7 +45,7 @@ Future<T> _doConnect<T extends Nyxx>(ApiOptions apiOptions, ClientOptions client
 }
 
 /// A helper function to nest and execute calls to plugin close methods.
-Future<void> _doClose(Nyxx client, Future<void> Function() close, List<NyxxPlugin> plugins) {
+Future<void> _pluginClose(Nyxx client, Future<void> Function() close, List<NyxxPlugin> plugins) {
   close = plugins.fold(
     close,
     (previousClose, plugin) => () => plugin.doClose(client, previousClose),
@@ -72,12 +72,14 @@ abstract class Nyxx {
   ClientOptions get options;
 
   /// The logger for this client.
-  Logger get logger;
+  Logger get logger => options.logger;
 
   /// The cache manager for this client.
-  CacheManager get cache;
+  late final CacheManager cache = CacheManager(this);
 
-  Completer<void> get _initializedCompleter;
+  final Completer<void> _initializedCompleter = Completer();
+  final Completer<void> _doneCompleter = Completer();
+  bool _isClosed = false;
 
   /// Create an instance of [NyxxRest] that can perform requests to the HTTP API and is
   /// authenticated with a bot token.
@@ -86,7 +88,7 @@ abstract class Nyxx {
 
   /// Create an instance of [NyxxRest] using the provided options.
   static Future<NyxxRest> connectRestWithOptions(RestApiOptions apiOptions, [RestClientOptions clientOptions = const RestClientOptions()]) async {
-    return _doConnect(apiOptions, clientOptions, () async {
+    return _pluginConnect(apiOptions, clientOptions, () async {
       clientOptions.logger
         ..info('Connecting to the REST API')
         ..fine('Token: ${apiOptions.token}, Authorization: ${apiOptions.authorizationHeader}, User-Agent: ${apiOptions.userAgent}')
@@ -94,9 +96,23 @@ abstract class Nyxx {
 
       final client = NyxxRest._(apiOptions, clientOptions);
 
-      return client
+      client
         .._application = await client.applications.fetchCurrentApplication()
         .._user = await client.users.fetchCurrentUser();
+
+      client.httpHandler.done.then((_) {
+        if (client._doneCompleter.isCompleted) return;
+
+        client._doneCompleter.completeError(NyxxException('HTTP handler was closed'), StackTrace.current);
+        client.close();
+      }, onError: (e, s) {
+        if (client._doneCompleter.isCompleted) return;
+
+        client._doneCompleter.completeError(e, s);
+        client.close();
+      });
+
+      return client;
     }, clientOptions.plugins);
   }
 
@@ -111,7 +127,7 @@ abstract class Nyxx {
   ///
   /// Note that `client.user.id` will contain [Snowflake.zero] if there no `identify` scope.
   static Future<NyxxOAuth2> connectOAuth2WithOptions(OAuth2ApiOptions apiOptions, [RestClientOptions clientOptions = const RestClientOptions()]) async {
-    return _doConnect(apiOptions, clientOptions, () async {
+    return _pluginConnect(apiOptions, clientOptions, () async {
       clientOptions.logger
         ..info('Connecting to the REST API via OAuth2')
         ..fine('Token: ${apiOptions.token}, Authorization: ${apiOptions.authorizationHeader}, User-Agent: ${apiOptions.userAgent}')
@@ -120,9 +136,23 @@ abstract class Nyxx {
       final client = NyxxOAuth2._(apiOptions, clientOptions);
       final information = await client.users.fetchCurrentOAuth2Information();
 
-      return client
+      client
         .._application = information.application
         .._user = information.user ?? PartialUser(id: Snowflake.zero, manager: client.users);
+
+      client.httpHandler.done.then((_) {
+        if (client._doneCompleter.isCompleted) return;
+
+        client._doneCompleter.completeError(NyxxException('HTTP handler was closed'), StackTrace.current);
+        client.close();
+      }, onError: (e, s) {
+        if (client._doneCompleter.isCompleted) return;
+
+        client._doneCompleter.completeError(e, s);
+        client.close();
+      });
+
+      return client;
     }, clientOptions.plugins);
   }
 
@@ -136,7 +166,7 @@ abstract class Nyxx {
     GatewayApiOptions apiOptions, [
     GatewayClientOptions clientOptions = const GatewayClientOptions(),
   ]) async {
-    return _doConnect(apiOptions, clientOptions, () async {
+    return _pluginConnect(apiOptions, clientOptions, () async {
       clientOptions.logger
         ..info('Connecting to the Gateway API')
         ..fine(
@@ -156,18 +186,62 @@ abstract class Nyxx {
       final gatewayManager = GatewayManager(client);
 
       final gatewayBot = await gatewayManager.fetchGatewayBot();
-      return client..gateway = await Gateway.connect(client, gatewayBot);
+      client.gateway = await Gateway.connect(client, gatewayBot);
+
+      client.httpHandler.done.then((_) {
+        if (client._doneCompleter.isCompleted) return;
+
+        client._doneCompleter.completeError(NyxxException('HTTP handler was closed'), StackTrace.current);
+        client.close();
+      }, onError: (e, s) {
+        if (client._doneCompleter.isCompleted) return;
+
+        client._doneCompleter.completeError(e, s);
+        client.close();
+      });
+
+      client.gateway.done.then((_) {
+        if (client._doneCompleter.isCompleted) return;
+
+        client._doneCompleter.completeError(NyxxException('Gateway was closed'), StackTrace.current);
+        client.close();
+      }, onError: (e, s) {
+        if (client._doneCompleter.isCompleted) return;
+
+        client._doneCompleter.completeError(e, s);
+        client.close();
+      });
+
+      return client;
     }, clientOptions.plugins);
   }
 
   /// Close this client and any underlying resources.
   ///
   /// The client should not be used after this is called and unexpected behavior may occur.
-  Future<void> close();
+  Future<void> close() {
+    logger.info('Closing client');
+
+    if (!_isClosed) {
+      _isClosed = true;
+      final closeFuture = _pluginClose(this, _doClose, options.plugins);
+
+      if (!_doneCompleter.isCompleted) {
+        _doneCompleter.complete(closeFuture);
+      } else {
+        closeFuture.ignore();
+      }
+    }
+
+    assert(_doneCompleter.isCompleted);
+    return _doneCompleter.future;
+  }
+
+  Future<void> _doClose();
 }
 
 /// A client that can make requests to the HTTP API and is authenticated with a bot token.
-class NyxxRest with ManagerMixin implements Nyxx {
+class NyxxRest extends Nyxx with ManagerMixin {
   @override
   final RestApiOptions apiOptions;
 
@@ -184,15 +258,6 @@ class NyxxRest with ManagerMixin implements Nyxx {
   /// The user associated with this client.
   PartialUser get user => _user;
   late final PartialUser _user;
-
-  @override
-  Logger get logger => options.logger;
-
-  @override
-  final Completer<void> _initializedCompleter = Completer();
-
-  @override
-  late final CacheManager cache = CacheManager(this);
 
   NyxxRest._(this.apiOptions, this.options);
 
@@ -215,13 +280,10 @@ class NyxxRest with ManagerMixin implements Nyxx {
       users.listCurrentUserGuilds(before: before, after: after, limit: limit);
 
   @override
-  Future<void> close() {
-    logger.info('Closing client');
-    return _doClose(this, () async => httpHandler.close(), options.plugins);
-  }
+  Future<void> _doClose() => httpHandler.close();
 }
 
-class NyxxOAuth2 with ManagerMixin implements NyxxRest {
+class NyxxOAuth2 extends Nyxx with ManagerMixin implements NyxxRest {
   @override
   final OAuth2ApiOptions apiOptions;
 
@@ -230,9 +292,6 @@ class NyxxOAuth2 with ManagerMixin implements NyxxRest {
 
   @override
   late final HttpHandler httpHandler = Oauth2HttpHandler(this);
-
-  @override
-  Logger get logger => options.logger;
 
   @override
   PartialApplication get application => _application;
@@ -245,12 +304,6 @@ class NyxxOAuth2 with ManagerMixin implements NyxxRest {
 
   @override
   late final PartialUser _user;
-
-  @override
-  final Completer<void> _initializedCompleter = Completer();
-
-  @override
-  late final CacheManager cache = CacheManager(this);
 
   NyxxOAuth2._(this.apiOptions, this.options);
 
@@ -265,14 +318,11 @@ class NyxxOAuth2 with ManagerMixin implements NyxxRest {
       users.listCurrentUserGuilds(before: before, after: after, limit: limit);
 
   @override
-  Future<void> close() {
-    logger.info('Closing client');
-    return _doClose(this, () async => httpHandler.close(), options.plugins);
-  }
+  Future<void> _doClose() => httpHandler.close();
 }
 
 /// A client that can make requests to the HTTP API, connects to the Gateway and is authenticated with a bot token.
-class NyxxGateway with ManagerMixin, EventMixin implements NyxxRest {
+class NyxxGateway extends Nyxx with ManagerMixin, EventMixin implements NyxxRest {
   @override
   final GatewayApiOptions apiOptions;
 
@@ -299,15 +349,6 @@ class NyxxGateway with ManagerMixin, EventMixin implements NyxxRest {
   @override
   late final Gateway gateway;
 
-  @override
-  Logger get logger => options.logger;
-
-  @override
-  final Completer<void> _initializedCompleter = Completer();
-
-  @override
-  late final CacheManager cache = CacheManager(this);
-
   NyxxGateway._(this.apiOptions, this.options);
 
   @override
@@ -327,11 +368,8 @@ class NyxxGateway with ManagerMixin, EventMixin implements NyxxRest {
   void updatePresence(PresenceBuilder builder) => gateway.updatePresence(builder);
 
   @override
-  Future<void> close() {
-    logger.info('Closing client');
-    return _doClose(this, () async {
-      await gateway.close();
-      httpHandler.close();
-    }, options.plugins);
+  Future<void> _doClose() async {
+    await gateway.close();
+    await httpHandler.close();
   }
 }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:logging/logging.dart';
-import 'package:meta/meta.dart';
 import 'package:nyxx/src/builders/presence.dart';
 import 'package:nyxx/src/builders/voice.dart';
 import 'package:nyxx/src/cache/cache.dart';
@@ -36,8 +35,7 @@ Future<T> _pluginConnect<T extends Nyxx>(ApiOptions apiOptions, ClientOptions cl
   final originalConnect = connect;
 
   connect = plugins.fold(
-    () async => await originalConnect()
-      .._initializedCompleter.complete(),
+    originalConnect,
     (previousConnect, plugin) => () async => actualClientType.castInstance(await plugin.doConnect(apiOptions, clientOptions, previousConnect)),
   );
 
@@ -51,13 +49,6 @@ Future<void> _pluginClose(Nyxx client, Future<void> Function() close, List<NyxxP
     (previousClose, plugin) => () => plugin.doClose(client, previousClose),
   );
   return close();
-}
-
-@internal
-extension InternalReady on Nyxx {
-  /// A future that completes when this client is initialized and can be passed to user defined callbacks.
-  @internal
-  Future<void> get initialized => _initializedCompleter.future;
 }
 
 /// The base class for clients interacting with the Discord API.
@@ -77,7 +68,6 @@ abstract class Nyxx {
   /// The cache manager for this client.
   late final CacheManager cache = CacheManager(this);
 
-  final Completer<void> _initializedCompleter = Completer();
   final Completer<void> _doneCompleter = Completer();
   bool _isClosed = false;
 

--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -94,29 +94,35 @@ class SkuNotFoundException extends NyxxException {
 }
 
 /// An error thrown when a shard disconnects unexpectedly.
-class ShardDisconnectedError extends Error {
+class ShardDisconnectedError extends Error implements NyxxException {
   /// The shard that was disconnected.
   final Shard shard;
+
+  @override
+  String get message => 'Shard ${shard.id} disconnected unexpectedly';
 
   /// Create a new [ShardDisconnectedError].
   ShardDisconnectedError(this.shard);
 
   @override
-  String toString() => 'Shard ${shard.id} disconnected unexpectedly';
+  String toString() => message;
 }
 
 /// An error thrown when the number of remaining sessions becomes too low.
 ///
 /// The threshold for this can be configured in [GatewayClientOptions.minimumSessionStarts].
-class OutOfRemainingSessionsError extends Error {
+class OutOfRemainingSessionsError extends Error implements NyxxException {
   /// The [GatewayBot] containing the information that triggered the error.
   final GatewayBot gatewayBot;
+
+  @override
+  String get message => 'Out of remaining session starts (${gatewayBot.sessionStartLimit.remaining} left)';
 
   /// Create a new [OutOfRemainingSessionsError].
   OutOfRemainingSessionsError(this.gatewayBot);
 
   @override
-  String toString() => 'Out of remaining session starts (${gatewayBot.sessionStartLimit.remaining} left)';
+  String toString() => message;
 }
 
 /// An error thrown when [MessageResponse.acknowledge] is called on an already acknowledged interaction.

--- a/lib/src/gateway/gateway.dart
+++ b/lib/src/gateway/gateway.dart
@@ -161,7 +161,7 @@ class Gateway extends GatewayManager with EventParser {
                 await delayCompleter.future;
                 _startOrIdentifyTimers.remove(delayTimer);
               });
-            } else if (event case EventReceived(event: ReadyEvent())) {
+            } else if (event case EventReceived(event: RawDispatchEvent(name: 'READY'))) {
               if (!_connectedCompleter.isCompleted) {
                 _connectedCompleter.complete();
               }

--- a/lib/src/gateway/gateway.dart
+++ b/lib/src/gateway/gateway.dart
@@ -229,7 +229,14 @@ class Gateway extends GatewayManager with EventParser {
     return gateway;
   }
 
+  /// A future that completes when this [Gateway] instance closes.
+  ///
+  /// If this [Gateway] closes because of an error, this future will complete with that error.
+  Future<void> get done => _doneCompleter.future;
+
   /// Close this [Gateway] instance, disconnecting all shards and closing the event streams.
+  ///
+  /// Returns the same future as [done].
   Future<void> close() async {
     Future<void> doClose() async {
       _isClosed = true;
@@ -260,11 +267,6 @@ class Gateway extends GatewayManager with EventParser {
     assert(_doneCompleter.isCompleted);
     return _doneCompleter.future;
   }
-
-  /// A future that completes when this [Gateway] instance closes.
-  ///
-  /// If this [Gateway] closes because of an error, this future will complete with that error.
-  Future<void> get done => _doneCompleter.future;
 
   /// Compute the ID of the shard that handles events for [guildId].
   int shardIdFor(Snowflake guildId) => (guildId.value >> 22) % totalShards;

--- a/lib/src/gateway/gateway.dart
+++ b/lib/src/gateway/gateway.dart
@@ -110,13 +110,11 @@ class Gateway extends GatewayManager with EventParser {
     // A mapping of rateLimitId (shard.id % maxConcurrency) to Futures that complete when the identify lock for that rate_limit_key is no longer used.
     final identifyLocks = <int, Future<void>>{};
 
-    client.initialized.then((_) {
-      _startOrIdentifyTimers.add(Timer(Duration(seconds: 10), () {
-        // Drain events so we parse and cache gateway events.
-        // Don't drain immediately so users can install their own event handlers and receive buffered events.
-        events.drain().ignore();
-      }));
-    });
+    _startOrIdentifyTimers.add(Timer(Duration(seconds: 10), () {
+      // Drain events so we parse and cache gateway events.
+      // Don't drain immediately so users can install their own event handlers and receive buffered events.
+      events.drain().ignore();
+    }));
 
     // Handle messages from the shards and start them according to their rate limit key.
     for (final shard in shards) {

--- a/lib/src/gateway/gateway.dart
+++ b/lib/src/gateway/gateway.dart
@@ -131,58 +131,65 @@ class Gateway extends GatewayManager with EventParser {
       });
       _startOrIdentifyTimers.add(startTimer);
 
-      runZonedGuarded(() {
-        shard.listen(
-          (event) {
-            _messagesController.add(event);
-
-            if (event is RequestingIdentify) {
-              final currentLock = identifyLocks[rateLimitKey] ?? Future.value();
-              identifyLocks[rateLimitKey] = currentLock.then((_) async {
-                if (_isClosed) return;
-
-                if (remainingIdentifyRequests < client.options.minimumSessionStarts * 5) {
-                  logger.warning('$remainingIdentifyRequests session starts remaining');
-                }
-
-                if (remainingIdentifyRequests < client.options.minimumSessionStarts) {
-                  throw OutOfRemainingSessionsError(gatewayBot);
-                }
-
-                remainingIdentifyRequests--;
-                shard.add(Identify());
-
-                // Don't use Future.delayed so that we can exit early if close() is called.
-                // If we use Future.delayed, the program will remain alive until it is complete, even if nothing is waiting on it.
-                // This code is roughly equivalent to `await Future.delayed(identifyDelay)`
-                final delayCompleter = Completer<void>();
-                final delayTimer = Timer(identifyDelay, delayCompleter.complete);
-                _startOrIdentifyTimers.add(delayTimer);
-                await delayCompleter.future;
-                _startOrIdentifyTimers.remove(delayTimer);
-              });
-            } else if (event case EventReceived(event: RawDispatchEvent(name: 'READY'))) {
-              if (!_connectedCompleter.isCompleted) {
-                _connectedCompleter.complete();
-              }
-            }
-          },
-          onError: _messagesController.addError,
-          cancelOnError: false,
-        );
-
-        // Error completions here will be caught by the zone handler.
-        shard.done.then((_) {
-          if (!_isClosed) {
-            throw ShardDisconnectedError(shard);
-          }
-        });
-      }, (e, s) {
+      void handleError(Object error, StackTrace stackTrace) {
         if (!_doneCompleter.isCompleted) {
-          _doneCompleter.completeError(e, s);
+          _doneCompleter.completeError(error, stackTrace);
           close();
         }
-      });
+      }
+
+      runZonedGuarded(
+        () {
+          shard.listen(
+            (event) {
+              _messagesController.add(event);
+
+              if (event is RequestingIdentify) {
+                final currentLock = identifyLocks[rateLimitKey] ?? Future.value();
+                identifyLocks[rateLimitKey] = currentLock.then((_) async {
+                  if (_isClosed) return;
+
+                  if (remainingIdentifyRequests < client.options.minimumSessionStarts * 5) {
+                    logger.warning('$remainingIdentifyRequests session starts remaining');
+                  }
+
+                  if (remainingIdentifyRequests < client.options.minimumSessionStarts) {
+                    throw OutOfRemainingSessionsError(gatewayBot);
+                  }
+
+                  remainingIdentifyRequests--;
+                  shard.add(Identify());
+
+                  // Don't use Future.delayed so that we can exit early if close() is called.
+                  // If we use Future.delayed, the program will remain alive until it is complete, even if nothing is waiting on it.
+                  // This code is roughly equivalent to `await Future.delayed(identifyDelay)`
+                  final delayCompleter = Completer<void>();
+                  final delayTimer = Timer(identifyDelay, delayCompleter.complete);
+                  _startOrIdentifyTimers.add(delayTimer);
+                  await delayCompleter.future;
+                  _startOrIdentifyTimers.remove(delayTimer);
+                });
+              } else if (event case EventReceived(event: RawDispatchEvent(name: 'READY'))) {
+                if (!_connectedCompleter.isCompleted) {
+                  _connectedCompleter.complete();
+                }
+              }
+            },
+            onError: _messagesController.addError,
+            cancelOnError: false,
+          );
+        },
+        handleError,
+      );
+
+      shard.done.then(
+        (_) {
+          if (!_isClosed) {
+            handleError(ShardDisconnectedError(shard), StackTrace.current);
+          }
+        },
+        onError: handleError,
+      );
     }
   }
 

--- a/lib/src/gateway/gateway.dart
+++ b/lib/src/gateway/gateway.dart
@@ -248,9 +248,11 @@ class Gateway extends GatewayManager with EventParser {
         timer.cancel();
       }
 
-      await Future.wait(shards.map((shard) => shard.close()));
-
-      _messagesController.close();
+      try {
+        await Future.wait(shards.map((shard) => shard.close()));
+      } finally {
+        _messagesController.close();
+      }
     }
 
     if (!_isClosed) {

--- a/lib/src/gateway/gateway.dart
+++ b/lib/src/gateway/gateway.dart
@@ -71,6 +71,10 @@ class Gateway extends GatewayManager with EventParser {
 
   final StreamController<ShardMessage> _messagesController = StreamController();
 
+  final Completer<void> _connectedCompleter = Completer();
+  final Completer<void> _doneCompleter = Completer();
+  bool _isClosed = false;
+
   /// A stream of dispatch events received from all shards.
   // Make this late instead of a getter so only a single subscription is made, which prevents events from being parsed multiple times.
   late final Stream<DispatchEvent> events = messages.transform(StreamTransformer.fromBind((messages) async* {
@@ -86,8 +90,6 @@ class Gateway extends GatewayManager with EventParser {
       yield parsedEvent;
     }
   })).asBroadcastStream();
-
-  bool _closing = false;
 
   /// The average latency across all shards in this [Gateway].
   ///
@@ -131,50 +133,58 @@ class Gateway extends GatewayManager with EventParser {
       });
       _startOrIdentifyTimers.add(startTimer);
 
-      shard.listen(
-        (event) {
-          _messagesController.add(event);
+      runZonedGuarded(() {
+        shard.listen(
+          (event) {
+            _messagesController.add(event);
 
-          if (event is RequestingIdentify) {
-            final currentLock = identifyLocks[rateLimitKey] ?? Future.value();
-            identifyLocks[rateLimitKey] = currentLock.then((_) async {
-              if (_closing) return;
+            if (event is RequestingIdentify) {
+              final currentLock = identifyLocks[rateLimitKey] ?? Future.value();
+              identifyLocks[rateLimitKey] = currentLock.then((_) async {
+                if (_isClosed) return;
 
-              if (remainingIdentifyRequests < client.options.minimumSessionStarts * 5) {
-                logger.warning('$remainingIdentifyRequests session starts remaining');
+                if (remainingIdentifyRequests < client.options.minimumSessionStarts * 5) {
+                  logger.warning('$remainingIdentifyRequests session starts remaining');
+                }
+
+                if (remainingIdentifyRequests < client.options.minimumSessionStarts) {
+                  throw OutOfRemainingSessionsError(gatewayBot);
+                }
+
+                remainingIdentifyRequests--;
+                shard.add(Identify());
+
+                // Don't use Future.delayed so that we can exit early if close() is called.
+                // If we use Future.delayed, the program will remain alive until it is complete, even if nothing is waiting on it.
+                // This code is roughly equivalent to `await Future.delayed(identifyDelay)`
+                final delayCompleter = Completer<void>();
+                final delayTimer = Timer(identifyDelay, delayCompleter.complete);
+                _startOrIdentifyTimers.add(delayTimer);
+                await delayCompleter.future;
+                _startOrIdentifyTimers.remove(delayTimer);
+              });
+            } else if (event case EventReceived(event: ReadyEvent())) {
+              if (!_connectedCompleter.isCompleted) {
+                _connectedCompleter.complete();
               }
+            }
+          },
+          onError: _messagesController.addError,
+          cancelOnError: false,
+        );
 
-              if (remainingIdentifyRequests < client.options.minimumSessionStarts) {
-                await client.close();
-                throw OutOfRemainingSessionsError(gatewayBot);
-              }
-
-              remainingIdentifyRequests--;
-              shard.add(Identify());
-
-              // Don't use Future.delayed so that we can exit early if close() is called.
-              // If we use Future.delayed, the program will remain alive until it is complete, even if nothing is waiting on it.
-              // This code is roughly equivalent to `await Future.delayed(identifyDelay)`
-              final delayCompleter = Completer<void>();
-              final delayTimer = Timer(identifyDelay, delayCompleter.complete);
-              _startOrIdentifyTimers.add(delayTimer);
-              await delayCompleter.future;
-              _startOrIdentifyTimers.remove(delayTimer);
-            });
+        // Error completions here will be caught by the zone handler.
+        shard.done.then((_) {
+          if (!_isClosed) {
+            throw ShardDisconnectedError(shard);
           }
-        },
-        onError: _messagesController.addError,
-        onDone: () async {
-          if (_closing) {
-            return;
-          }
-
-          await client.close();
-
-          throw ShardDisconnectedError(shard);
-        },
-        cancelOnError: false,
-      );
+        });
+      }, (e, s) {
+        if (!_doneCompleter.isCompleted) {
+          _doneCompleter.completeError(e, s);
+          close();
+        }
+      });
     }
   }
 
@@ -214,19 +224,47 @@ class Gateway extends GatewayManager with EventParser {
     );
 
     final shards = shardIds.map((id) => Shard.connect(id, totalShards, client.apiOptions, gatewayBot.url, client));
-    return Gateway(client, gatewayBot, await Future.wait(shards), totalShards, shardIds);
+    final gateway = Gateway(client, gatewayBot, await Future.wait(shards), totalShards, shardIds);
+    await gateway._connectedCompleter.future;
+    return gateway;
   }
 
   /// Close this [Gateway] instance, disconnecting all shards and closing the event streams.
   Future<void> close() async {
-    _closing = true;
-    // Make sure we don't start any shards after we have closed.
-    for (final timer in _startOrIdentifyTimers) {
-      timer.cancel();
+    Future<void> doClose() async {
+      _isClosed = true;
+
+      if (!_connectedCompleter.isCompleted) {
+        _connectedCompleter.complete(_doneCompleter.future);
+      }
+
+      // Make sure we don't start any shards after we have closed.
+      for (final timer in _startOrIdentifyTimers) {
+        timer.cancel();
+      }
+
+      await Future.wait(shards.map((shard) => shard.close()));
+
+      _messagesController.close();
     }
-    await Future.wait(shards.map((shard) => shard.close()));
-    _messagesController.close();
+
+    if (!_isClosed) {
+      final closeFuture = doClose();
+      if (!_doneCompleter.isCompleted) {
+        _doneCompleter.complete(closeFuture);
+      } else {
+        closeFuture.ignore();
+      }
+    }
+
+    assert(_doneCompleter.isCompleted);
+    return _doneCompleter.future;
   }
+
+  /// A future that completes when this [Gateway] instance closes.
+  ///
+  /// If this [Gateway] closes because of an error, this future will complete with that error.
+  Future<void> get done => _doneCompleter.future;
 
   /// Compute the ID of the shard that handles events for [guildId].
   int shardIdFor(Snowflake guildId) => (guildId.value >> 22) % totalShards;

--- a/lib/src/gateway/message.dart
+++ b/lib/src/gateway/message.dart
@@ -105,3 +105,12 @@ class Identify extends GatewayMessage {}
 ///
 /// The shard can no longer be used after this is sent.
 class Dispose extends GatewayMessage {}
+
+/// A gateway message sent to instruct the shard to end its current connection and create a new one.
+///
+/// Cannot be used to restart a disconnected shard.
+class Reconnect extends GatewayMessage {
+  final bool allowResume;
+
+  Reconnect({this.allowResume = true});
+}

--- a/lib/src/gateway/shard.dart
+++ b/lib/src/gateway/shard.dart
@@ -178,6 +178,11 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
     }));
   }
 
+  /// End the current connection and create a new one.
+  ///
+  /// Cannot be used to restart this shard if it has disconnected.
+  void reconnect({bool allowResume = true}) => add(Reconnect(allowResume: allowResume));
+
   @override
   void add(GatewayMessage event) {
     if (event is Send) {

--- a/lib/src/gateway/shard.dart
+++ b/lib/src/gateway/shard.dart
@@ -49,6 +49,8 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
   /// This is updated for each [HeartbeatAckEvent] received. If no [HeartbeatAckEvent] has been received, this will be [Duration.zero].
   Duration get latency => _latency;
 
+  final Stopwatch _disconnectedStopwatch = Stopwatch();
+
   /// Create a new [Shard].
   Shard(this.id, this.isolate, this.receiveStream, this.sendPort, this.client) {
     // Technically this code is unsafe as plugins may be given a client that does not yet have a Gateway assigned.
@@ -86,6 +88,7 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
         }
       } else if (message is Reconnecting) {
         logger.info('Reconnecting: ${message.reason}');
+        _disconnectedStopwatch.start();
       } else if (message is EventReceived) {
         final event = message.event;
 
@@ -111,11 +114,19 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
             ..fine('Receive event: ${event.name}')
             ..finer('Seq: ${event.seq}, Data: ${event.payload}');
 
-          if (event.name == 'READY') {
-            logger.info('Connected to Gateway');
-          } else if (event.name == 'RESUMED') {
-            logger.info('Reconnected to Gateway');
+          var timerSuffix = '';
+          if (_disconnectedStopwatch.elapsed > Duration(seconds: 5)) {
+            timerSuffix = ' (after ${_disconnectedStopwatch.elapsed} spent disconnected)';
           }
+
+          if (event.name == 'READY') {
+            logger.info('Connected to Gateway$timerSuffix');
+          } else if (event.name == 'RESUMED') {
+            logger.info('Reconnected to Gateway$timerSuffix');
+          }
+
+          _disconnectedStopwatch.stop();
+          _disconnectedStopwatch.reset();
         }
       } else if (message is RequestingIdentify) {
         logger.fine('Ready to identify');
@@ -193,6 +204,8 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
       logger.info('Disposing');
     } else if (event is Identify) {
       logger.info('Connecting to Gateway');
+    } else if (event is StartShard) {
+      _disconnectedStopwatch.start();
     }
 
     _sendController.add(event);
@@ -219,13 +232,15 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
       // _rawReceiveController and _transformedReceiveController are closed by the piped
       // receive port stream being closed.
 
-      // Give the isolate time to shut down cleanly, but kill it if it takes too long.
-      try {
-        // Wait for disconnection confirmation.
-        await firstWhere((message) => message is Disconnecting).then(drain).timeout(const Duration(seconds: 5));
-      } on TimeoutException {
-        logger.warning('Isolate took too long to shut down, killing it');
-        isolate.kill(priority: Isolate.immediate);
+      if (!_rawReceiveController.isClosed) {
+        // Give the isolate time to shut down cleanly, but kill it if it takes too long.
+        try {
+          // Wait for disconnection confirmation.
+          await firstWhere((message) => message is Disconnecting).then(drain).timeout(const Duration(seconds: 5));
+        } on TimeoutException {
+          logger.warning('Isolate took too long to shut down, killing it');
+          isolate.kill(priority: Isolate.immediate);
+        }
       }
     }
 

--- a/lib/src/gateway/shard.dart
+++ b/lib/src/gateway/shard.dart
@@ -51,19 +51,22 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
 
   /// Create a new [Shard].
   Shard(this.id, this.isolate, this.receiveStream, this.sendPort, this.client) {
-    client.initialized.then((_) {
-      final sendStream = client.options.plugins.fold(
-        _sendController.stream,
-        (previousValue, plugin) => plugin.interceptGatewayMessages(this, previousValue),
-      );
-      sendStream.listen(sendPort.send, cancelOnError: false, onDone: close);
+    // Technically this code is unsafe as plugins may be given a client that does not yet have a Gateway assigned.
+    // We have the choice between doing this _or_ returning a client with no connected shards from Nyxx.connectGateway.
+    // We prefer to wait for a shard to finish connecting before returning the client from Nyxx.connectGateway to ensure
+    // that any connection issues (notably lack of session starts) causes the Nyxx.connectGateway call itself to fail, and
+    // not just the NyxxGateway.done future.
+    final sendStream = client.options.plugins.fold(
+      _sendController.stream,
+      (previousValue, plugin) => plugin.interceptGatewayMessages(this, previousValue),
+    );
+    sendStream.listen(sendPort.send, cancelOnError: false, onDone: close);
 
-      final transformedReceiveStream = client.options.plugins.fold(
-        _rawReceiveController.stream,
-        (previousValue, plugin) => plugin.interceptShardMessages(this, previousValue),
-      );
-      transformedReceiveStream.pipe(_transformedReceiveController);
-    });
+    final transformedReceiveStream = client.options.plugins.fold(
+      _rawReceiveController.stream,
+      (previousValue, plugin) => plugin.interceptShardMessages(this, previousValue),
+    );
+    transformedReceiveStream.pipe(_transformedReceiveController);
 
     receiveStream.cast<ShardMessage>().pipe(_rawReceiveController);
 

--- a/lib/src/gateway/shard.dart
+++ b/lib/src/gateway/shard.dart
@@ -5,6 +5,7 @@ import 'package:logging/logging.dart';
 import 'package:nyxx/src/api_options.dart';
 import 'package:nyxx/src/builders/voice.dart';
 import 'package:nyxx/src/client.dart';
+import 'package:nyxx/src/errors.dart';
 import 'package:nyxx/src/gateway/message.dart';
 import 'package:nyxx/src/gateway/shard_runner.dart';
 import 'package:nyxx/src/models/gateway/event.dart';
@@ -39,6 +40,7 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
   Logger get logger => Logger('${client.options.loggerName}.Shards[$id]');
 
   final Completer<void> _doneCompleter = Completer();
+  bool _isClosed = false;
 
   Duration _latency = Duration.zero;
 
@@ -65,7 +67,7 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
 
     receiveStream.cast<ShardMessage>().pipe(_rawReceiveController);
 
-    final subscription = listen((message) {
+    listen((message) {
       if (message is Sent) {
         logger
           ..fine('Sent payload: ${message.payload.opcode.name}')
@@ -74,6 +76,11 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
         logger.warning('Error: ${message.error}', message.error, message.stackTrace);
       } else if (message is Disconnecting) {
         logger.info('Disconnecting: ${message.reason}');
+
+        if (!_doneCompleter.isCompleted) {
+          _doneCompleter.completeError(NyxxException('Shard is disconnecting: ${message.reason}'), StackTrace.current);
+          close();
+        }
       } else if (message is Reconnecting) {
         logger.info('Reconnecting: ${message.reason}');
       } else if (message is EventReceived) {
@@ -110,13 +117,15 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
       } else if (message is RequestingIdentify) {
         logger.fine('Ready to identify');
       }
-    });
-
-    subscription.asFuture().then((value) {
-      // Can happen if the shard closes unexpectedly.
-      // Prevents further calls to close() from attempting to add events.
+    }, onError: (e, s) {
       if (!_doneCompleter.isCompleted) {
-        _doneCompleter.complete(value);
+        _doneCompleter.completeError(e, s);
+        close();
+      }
+    }, onDone: () {
+      if (!_doneCompleter.isCompleted) {
+        _doneCompleter.completeError(NyxxException('Shard closed unexpectedly'), StackTrace.current);
+        close();
       }
     });
   }
@@ -193,11 +202,9 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
 
   @override
   Future<void> close() {
-    if (_doneCompleter.isCompleted) {
-      return _doneCompleter.future;
-    }
-
     Future<void> doClose() async {
+      _isClosed = true;
+
       add(Dispose());
 
       _sendController.close();
@@ -214,7 +221,17 @@ class Shard extends Stream<ShardMessage> implements StreamSink<GatewayMessage> {
       }
     }
 
-    _doneCompleter.complete(doClose());
+    if (!_isClosed) {
+      final closeFuture = doClose();
+
+      if (!_doneCompleter.isCompleted) {
+        _doneCompleter.complete(closeFuture);
+      } else {
+        closeFuture.ignore();
+      }
+    }
+
+    assert(_doneCompleter.isCompleted);
     return _doneCompleter.future;
   }
 

--- a/lib/src/gateway/shard_runner.dart
+++ b/lib/src/gateway/shard_runner.dart
@@ -100,10 +100,6 @@ class ShardRunner {
         disposing = true;
         connection?.close();
 
-        // We might get a dispose request while we are waiting to identify.
-        // Add an event to the identify stream so we break out of the wait.
-        identifyController.add(null);
-
         // We need to start the shard to jump ahead to the check for exiting the shard.
         if (!startCompleter.isCompleted) {
           startCompleter.complete(StartShard());
@@ -154,6 +150,13 @@ class ShardRunner {
 
           heartbeatInterval = hello.heartbeatInterval;
           startHeartbeat();
+
+          connection!.done.then((_) {
+            heartbeatTimer?.cancel();
+            // The connection might close while we are waiting to identify.
+            // Add an event to the identify stream so we break out of the wait.
+            identifyController.add(null);
+          });
 
           // If we can resume (the connection loop was restarted) and we have the information needed, try to resume.
           // Otherwise, identify.
@@ -219,7 +222,6 @@ class ShardRunner {
 
           // Wait for the current connection to end, either due to a remote close or due to us disconnecting.
           await subscription.asFuture();
-          heartbeatTimer?.cancel();
 
           // Check if we can resume based on close code if the connection was closed by Discord.
           if (connection!.localCloseCode == null) {

--- a/lib/src/gateway/shard_runner.dart
+++ b/lib/src/gateway/shard_runner.dart
@@ -86,7 +86,7 @@ class ShardRunner {
 
     // identifyController serves as a notification system for Identify messages.
     // Any Identify messages received are added to this stream.
-    final identifyController = StreamController<Identify>.broadcast();
+    final identifyController = StreamController<Identify?>.broadcast();
 
     // startCompleter is completed when the Gateway instance is ready for this shard to start.
     final startCompleter = Completer<StartShard>();
@@ -101,11 +101,8 @@ class ShardRunner {
         connection?.close();
 
         // We might get a dispose request while we are waiting to identify.
-        // Add an error to the identify stream so we break out of the wait.
-        identifyController.addError(
-          Exception('Out of remaining session starts'),
-          StackTrace.current,
-        );
+        // Add an event to the identify stream so we break out of the wait.
+        identifyController.add(null);
 
         // We need to start the shard to jump ahead to the check for exiting the shard.
         if (!startCompleter.isCompleted) {
@@ -162,7 +159,10 @@ class ShardRunner {
           } else {
             // Request to identify and wait for the confirmation.
             controller.add(RequestingIdentify());
-            await identifyController.stream.first;
+            final identify = await identifyController.stream.first;
+            if (identify == null) {
+              continue;
+            }
 
             await sendIdentify();
           }
@@ -241,7 +241,9 @@ class ShardRunner {
           // Prevents the while-true loop from looping too often when no internet is available.
           await Future.delayed(Duration(milliseconds: 100));
 
-          controller.add(Reconnecting(reason: 'Error on Gateway connection'));
+          if (!disposing) {
+            controller.add(Reconnecting(reason: 'Error on Gateway connection'));
+          }
         } finally {
           // Pause the send subscription until we are connected again.
           // The handler may already be paused if the error occurred before we had identified.

--- a/lib/src/gateway/shard_runner.dart
+++ b/lib/src/gateway/shard_runner.dart
@@ -219,6 +219,7 @@ class ShardRunner {
 
           // Wait for the current connection to end, either due to a remote close or due to us disconnecting.
           await subscription.asFuture();
+          heartbeatTimer?.cancel();
 
           // Check if we can resume based on close code if the connection was closed by Discord.
           if (connection!.localCloseCode == null) {

--- a/lib/src/gateway/shard_runner.dart
+++ b/lib/src/gateway/shard_runner.dart
@@ -84,9 +84,17 @@ class ShardRunner {
     })
       ..pause();
 
-    // identifyController serves as a notification system for Identify messages.
-    // Any Identify messages received are added to this stream.
-    final identifyController = StreamController<Identify?>.broadcast();
+    Completer<Identify?>? pendingIdentify;
+    Future<Identify?> requestIdentify() async {
+      if (pendingIdentify case final identify?) {
+        return identify.future;
+      }
+
+      controller.add(RequestingIdentify());
+      pendingIdentify = Completer();
+
+      return pendingIdentify!.future;
+    }
 
     // startCompleter is completed when the Gateway instance is ready for this shard to start.
     final startCompleter = Completer<StartShard>();
@@ -95,10 +103,11 @@ class ShardRunner {
       if (message is Send) {
         sendController.add(message);
       } else if (message is Identify) {
-        identifyController.add(message);
+        pendingIdentify?.complete(message);
       } else if (message is Dispose) {
         disposing = true;
         connection?.close();
+        pendingIdentify?.complete(null);
 
         // We need to start the shard to jump ahead to the check for exiting the shard.
         if (!startCompleter.isCompleted) {
@@ -117,6 +126,12 @@ class ShardRunner {
       } else if (message is Reconnect) {
         canResume = canResume && message.allowResume;
         connection?.close();
+
+        // i.e we have a pending request and it has not been fulfilled yet.
+        if (pendingIdentify?.isCompleted == false) {
+          pendingIdentify!.complete(null);
+          pendingIdentify = Completer();
+        }
       }
     });
 
@@ -137,6 +152,14 @@ class ShardRunner {
           // Initialize lastHeartbeatAcked to `true` so we don't immediately disconnect in heartbeat().
           lastHeartbeatAcked = true;
 
+          final goingToResume = canResume && seq != null && sessionId != null;
+          if (!goingToResume) {
+            final identify = await requestIdentify();
+            if (identify == null) {
+              continue;
+            }
+          }
+
           // Open the websocket connection.
           connection = await ShardConnection.connect(gatewayUri.toString(), this);
           connection!.onSent.listen(controller.add);
@@ -153,22 +176,14 @@ class ShardRunner {
 
           connection!.done.then((_) {
             heartbeatTimer?.cancel();
-            // The connection might close while we are waiting to identify.
-            // Add an event to the identify stream so we break out of the wait.
-            identifyController.add(null);
           });
 
           // If we can resume (the connection loop was restarted) and we have the information needed, try to resume.
           // Otherwise, identify.
-          if (canResume && seq != null && sessionId != null) {
+          if (goingToResume) {
             await sendResume();
           } else {
-            // Request to identify and wait for the confirmation.
-            controller.add(RequestingIdentify());
-            final identify = await identifyController.stream.first;
-            if (identify == null) {
-              continue;
-            }
+            pendingIdentify = null;
 
             await sendIdentify();
           }
@@ -272,7 +287,6 @@ class ShardRunner {
     asyncRun().then((_) {
       controller.close();
       sendController.close();
-      identifyController.close();
       messageHandler.cancel();
     });
 

--- a/lib/src/gateway/shard_runner.dart
+++ b/lib/src/gateway/shard_runner.dart
@@ -118,6 +118,9 @@ class ShardRunner {
         }
 
         startCompleter.complete(message);
+      } else if (message is Reconnect) {
+        canResume = canResume && message.allowResume;
+        connection?.close();
       }
     });
 

--- a/lib/src/http/handler.dart
+++ b/lib/src/http/handler.dart
@@ -97,6 +97,9 @@ class HttpHandler {
 
   final Set<Completer<void>> _pendingRateLimits = {};
 
+  final Completer<void> _doneCompleter = Completer();
+  bool _isClosed = false;
+
   /// Create a new [HttpHandler].
   ///
   /// {@macro http_handler}
@@ -216,6 +219,9 @@ class HttpHandler {
         _pendingRateLimits.add(completer);
         try {
           await completer.future;
+        } catch (e) {
+          // Add a proper stack trace.
+          Error.throwWithStackTrace(e, StackTrace.current);
         } finally {
           _pendingRateLimits.remove(completer);
           timer.cancel();
@@ -329,20 +335,39 @@ class HttpHandler {
     return parsedResponse;
   }
 
-  void close() {
-    // Timers associated with these completers will be cancelled in
-    // the finally block from the try/catch that the completer is awaited in.
-    for (final completer in _pendingRateLimits) {
-      completer.completeError(
-        ClientClosedError(),
-        StackTrace.current,
-      );
+  /// A future that completes when this HTTP handler closes.
+  ///
+  /// If this HTTP handler closes due to an error, this future will also complete with an error.
+  Future<void> get done => _doneCompleter.future;
+
+  /// Close this HTTP handler.
+  Future<void> close() {
+    Future<void> doClose() async {
+      _isClosed = true;
+
+      // Timers associated with these completers will be cancelled in
+      // the finally block from the try/catch that the completer is awaited in.
+      for (final completer in _pendingRateLimits) {
+        completer.completeError(ClientClosedError());
+      }
+
+      httpClient.close();
+      _onRequestController.close();
+      _onResponseController.close();
+      _onRateLimitController.close();
     }
 
-    httpClient.close();
-    _onRequestController.close();
-    _onResponseController.close();
-    _onRateLimitController.close();
+    if (!_isClosed) {
+      final closeFuture = doClose();
+      if (!_doneCompleter.isCompleted) {
+        _doneCompleter.complete(closeFuture);
+      } else {
+        closeFuture.ignore();
+      }
+    }
+
+    assert(_doneCompleter.isCompleted);
+    return _doneCompleter.future;
   }
 }
 

--- a/lib/src/http/handler.dart
+++ b/lib/src/http/handler.dart
@@ -341,6 +341,8 @@ class HttpHandler {
   Future<void> get done => _doneCompleter.future;
 
   /// Close this HTTP handler.
+  ///
+  /// Returns the same future as [done].
   Future<void> close() {
     Future<void> doClose() async {
       _isClosed = true;

--- a/test/integration/async_dispose_test.dart
+++ b/test/integration/async_dispose_test.dart
@@ -84,6 +84,9 @@ void main() {
         assetRequest,
         ...shardsDone,
         rateLimitedRequest,
+        client.done,
+        client.httpHandler.done,
+        client.gateway.done,
       ]);
 
       await client.close();

--- a/test/integration/async_dispose_test.dart
+++ b/test/integration/async_dispose_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 void main() {
   final testToken = Platform.environment['TEST_TOKEN'];
 
-  test('client.close() disposes all async resources', skip: testToken != null ? false : 'No test token provided', () async {
+  test('client.close() disposes all async resources', skip: testToken != null ? false : 'No test token provided', timeout: Timeout.parse('2m'), () async {
     final receivePort = ReceivePort();
 
     Future<void> createAndDisposeClient(SendPort sendPort) async {

--- a/test/integration/close_test.dart
+++ b/test/integration/close_test.dart
@@ -7,14 +7,14 @@ import 'package:test/test.dart';
 void main() {
   final testToken = Platform.environment['TEST_TOKEN'];
   group('close and error handling', timeout: Timeout.parse('2m'), skip: testToken != null, () {
-    Future<NyxxGateway> createClient({List<NyxxPlugin>? plugins}) async {
+    Future<NyxxGateway> createClient([GatewayClientOptions? options]) async {
       return await Nyxx.connectGatewayWithOptions(
         GatewayApiOptions(
           token: testToken!,
           intents: GatewayIntents.allUnprivileged,
           totalShards: 2,
         ),
-        GatewayClientOptions(plugins: plugins ?? []),
+        options ?? GatewayClientOptions(),
       );
     }
 
@@ -79,13 +79,28 @@ void main() {
     });
 
     test('Shard disconnection error', () async {
-      final client = await createClient(plugins: [FakeDisconnectPlugin()]);
+      final client = await createClient(GatewayClientOptions(plugins: [FakeDisconnectPlugin()]));
 
       expect(client.done, throwsA(isA<NyxxException>()));
       expect(client.httpHandler.done, completes);
       expect(client.gateway.done, throwsA(isA<NyxxException>()));
       expect(client.gateway.shards[0].done, throwsA(isA<NyxxException>()));
       expect(client.gateway.shards[1].done, completes);
+    });
+
+    test('Shard reconnection error', () async {
+      final options = ModifiableGatewayOptions();
+
+      final client = await createClient(options);
+
+      expect(client.done, throwsA(isA<NyxxException>()));
+      expect(client.httpHandler.done, completes);
+      expect(client.gateway.done, throwsA(isA<NyxxException>()));
+      expect(client.gateway.shards[0].done, completes);
+      expect(client.gateway.shards[1].done, completes);
+
+      options.minimumSessionStarts = 1000000;
+      client.gateway.shards[0].reconnect(allowResume: false);
     });
   });
 }
@@ -105,4 +120,10 @@ class FakeDisconnectPlugin extends NyxxPlugin<NyxxGateway> {
 
     return controller.stream;
   }
+}
+
+class ModifiableGatewayOptions extends GatewayClientOptions {
+  @override
+  // ignore: overridden_fields
+  int minimumSessionStarts = 10;
 }

--- a/test/integration/close_test.dart
+++ b/test/integration/close_test.dart
@@ -6,7 +6,7 @@ import 'package:test/test.dart';
 
 void main() {
   final testToken = Platform.environment['TEST_TOKEN'];
-  group('close and error handling', timeout: Timeout.parse('2m'), skip: testToken != null, () {
+  group('close and error handling', timeout: Timeout.parse('2m'), skip: testToken != null ? false : 'No test token provided', () {
     Future<NyxxGateway> createClient([GatewayClientOptions? options]) async {
       return await Nyxx.connectGatewayWithOptions(
         GatewayApiOptions(

--- a/test/integration/close_test.dart
+++ b/test/integration/close_test.dart
@@ -1,0 +1,108 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:nyxx/nyxx.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final testToken = Platform.environment['TEST_TOKEN'];
+  group('close and error handling', timeout: Timeout.parse('2m'), skip: testToken != null, () {
+    Future<NyxxGateway> createClient({List<NyxxPlugin>? plugins}) async {
+      return await Nyxx.connectGatewayWithOptions(
+        GatewayApiOptions(
+          token: testToken!,
+          intents: GatewayIntents.allUnprivileged,
+          totalShards: 2,
+        ),
+        GatewayClientOptions(plugins: plugins ?? []),
+      );
+    }
+
+    test('normal close', () async {
+      final client = await createClient();
+
+      expect(client.done, completes);
+      expect(client.httpHandler.done, completes);
+      expect(client.gateway.done, completes);
+      expect(client.gateway.shards[0].done, completes);
+      expect(client.gateway.shards[1].done, completes);
+
+      expect(client.close(), completes);
+    });
+
+    test('HTTP handler close', () async {
+      final client = await createClient();
+
+      expect(client.done, throwsA(isA<NyxxException>()));
+      expect(client.httpHandler.done, completes);
+      expect(client.gateway.done, completes);
+      expect(client.gateway.shards[0].done, completes);
+      expect(client.gateway.shards[1].done, completes);
+
+      expect(client.httpHandler.close(), completes);
+    });
+
+    test('Gateway close', () async {
+      final client = await createClient();
+
+      expect(client.done, throwsA(isA<NyxxException>()));
+      expect(client.httpHandler.done, completes);
+      expect(client.gateway.done, completes);
+      expect(client.gateway.shards[0].done, completes);
+      expect(client.gateway.shards[1].done, completes);
+
+      expect(client.gateway.close(), completes);
+    });
+
+    test('Shard close', () async {
+      final client = await createClient();
+
+      expect(client.done, throwsA(isA<NyxxException>()));
+      expect(client.httpHandler.done, completes);
+      expect(client.gateway.done, throwsA(isA<NyxxException>()));
+      expect(client.gateway.shards[0].done, completes);
+      expect(client.gateway.shards[1].done, completes);
+
+      expect(client.gateway.shards[0].close(), completes);
+    });
+
+    test('Shard isolate killed', () async {
+      final client = await createClient();
+
+      expect(client.done, throwsA(isA<NyxxException>()));
+      expect(client.httpHandler.done, completes);
+      expect(client.gateway.done, throwsA(isA<NyxxException>()));
+      expect(client.gateway.shards[0].done, throwsA(isA<NyxxException>()));
+      expect(client.gateway.shards[1].done, completes);
+
+      client.gateway.shards[0].isolate.kill();
+    });
+
+    test('Shard disconnection error', () async {
+      final client = await createClient(plugins: [FakeDisconnectPlugin()]);
+
+      expect(client.done, throwsA(isA<NyxxException>()));
+      expect(client.httpHandler.done, completes);
+      expect(client.gateway.done, throwsA(isA<NyxxException>()));
+      expect(client.gateway.shards[0].done, throwsA(isA<NyxxException>()));
+      expect(client.gateway.shards[1].done, completes);
+    });
+  });
+}
+
+class FakeDisconnectPlugin extends NyxxPlugin<NyxxGateway> {
+  @override
+  Stream<ShardMessage> interceptShardMessages(Shard shard, Stream<ShardMessage> messages) {
+    final controller = StreamController<ShardMessage>();
+
+    super.interceptShardMessages(shard, messages).listen((message) {
+      controller.add(message);
+
+      if (message case EventReceived(event: RawDispatchEvent(name: 'READY'))) {
+        controller.add(Disconnecting(reason: 'Test forced disconnect'));
+      }
+    }, onDone: controller.close);
+
+    return controller.stream;
+  }
+}

--- a/test/integration/gateway_integration_test.dart
+++ b/test/integration/gateway_integration_test.dart
@@ -56,6 +56,13 @@ void main() {
       }
       await expectLater(client.close(), completes);
     });
+
+    test('Fails without enough session starts', () async {
+      expect(
+        Nyxx.connectGateway(testToken!, GatewayIntents.none, options: GatewayClientOptions(minimumSessionStarts: 1000000)),
+        throwsA(isA<OutOfRemainingSessionsError>()),
+      );
+    });
   });
 
   group('NyxxGateway', skip: testToken != null ? false : 'No test token provided', () {

--- a/test/integration/gateway_integration_test.dart
+++ b/test/integration/gateway_integration_test.dart
@@ -9,7 +9,7 @@ void main() {
   final testToken = Platform.environment['TEST_TOKEN'];
   final testGuild = Platform.environment['TEST_GUILD'];
 
-  group('Nyxx.connectGateway', skip: testToken != null ? false : 'No test token provided', () {
+  group('Nyxx.connectGateway', skip: testToken != null ? false : 'No test token provided', timeout: Timeout.parse('2m'), () {
     Future<void> testClient(GatewayApiOptions options) async {
       late NyxxGateway client;
 


### PR DESCRIPTION
# Description

I feel like I make at least one of these "handle errors better" PRs each year. At least we're getting better and better.

This PR should make it so that Nyxx no longer throws any uncaught exceptions - everything is reported through `done` futures on the various parts of the client. This also ensures we distinguish between fatal errors (that complete `done` with an error and must also close the associated resource) and non fatal errors, where only a particular operation completes with an error and `done` is left uncompleted.