### PR TITLE
feat: allow usage of NyxxRest on Web by conditionally importing dart:ffi

### DIFF
--- a/lib/src/api_options.dart
+++ b/lib/src/api_options.dart
@@ -1,5 +1,4 @@
-import 'dart:ffi';
-import 'dart:io';
+import 'ffi_stub.dart' if (dart.library.ffi) 'ffi_real.dart';
 
 import 'package:nyxx/src/builders/presence.dart';
 import 'package:nyxx/src/intents.dart';
@@ -75,12 +74,6 @@ class OAuth2ApiOptions extends ApiOptions implements RestApiOptions {
   /// Create a new [OAuth2ApiOptions].
   OAuth2ApiOptions({required this.credentials, super.userAgent});
 }
-
-final zstdLibraryName = Platform.isWindows
-    ? 'zstd.dll'
-    : Platform.isMacOS
-        ? 'libzstd.dylib'
-        : 'libzstd.so';
 
 /// Options for connecting to the Discord API for making HTTP requests and connecting to the Gateway
 /// with a bot token.

--- a/lib/src/ffi_real.dart
+++ b/lib/src/ffi_real.dart
@@ -1,0 +1,9 @@
+export 'dart:ffi';
+import 'dart:io';
+
+/// The name of the zstd library on the current platform.
+final zstdLibraryName = Platform.isWindows
+    ? 'zstd.dll'
+    : Platform.isMacOS
+        ? 'libzstd.dylib'
+        : 'libzstd.so';

--- a/lib/src/ffi_stub.dart
+++ b/lib/src/ffi_stub.dart
@@ -1,0 +1,15 @@
+/// A stub for the dart:ffi library.
+class DynamicLibrary {
+  /// A stub for DynamicLibrary.open.
+  static DynamicLibrary open(String path) {
+    throw UnsupportedError('DynamicLibrary is not supported on this platform.');
+  }
+
+  /// A stub for DynamicLibrary.close.
+  void close() {
+    throw UnsupportedError('DynamicLibrary is not supported on this platform.');
+  }
+}
+
+/// A stub for the zstd library name.
+const zstdLibraryName = '';

--- a/lib/src/gateway/decompress_zstd_native.dart
+++ b/lib/src/gateway/decompress_zstd_native.dart
@@ -1,0 +1,77 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:ffi/ffi.dart';
+import 'package:nyxx/src/api_options.dart';
+import 'package:nyxx/src/errors.dart';
+import 'package:nyxx/src/ffi_real.dart';
+import 'package:zstd_ffi/_zstd.dart';
+
+Stream<dynamic> decompressZStdTransport(Stream<List<int>> raw) {
+  final library = DynamicLibrary.open(zstdLibraryName);
+  final zstd = ZStd(library);
+
+  final inputSize = zstd.ZSTD_DStreamInSize();
+  final inputPtr = malloc<ZSTD_inBuffer>();
+  inputPtr.ref.src = malloc<Uint8>(inputSize).cast<Void>();
+
+  final outputSize = zstd.ZSTD_DStreamOutSize();
+  final outputPtr = malloc<ZSTD_outBuffer>();
+  outputPtr.ref.dst = malloc<Uint8>(outputSize).cast<Void>();
+  outputPtr.ref.size = outputSize;
+
+  final dctx = zstd.ZSTD_createDCtx();
+  if (dctx == nullptr) {
+    malloc.free(inputPtr.ref.src);
+    malloc.free(inputPtr);
+    malloc.free(outputPtr.ref.dst);
+    malloc.free(outputPtr);
+
+    throw NyxxException('Unable to initialise Zstd dctx');
+  }
+  zstd.ZSTD_initDStream(dctx);
+
+  var lastRet = 0;
+
+  return raw.transform(StreamTransformer.fromHandlers(
+    handleData: (chunk, output) {
+      if (chunk is! Uint8List) {
+        chunk = Uint8List.fromList(chunk);
+      }
+
+      final result = BytesBuilder(copy: true);
+
+      for (int i = 0; i * inputSize < chunk.length; i++) {
+        final currentSlice = Uint8List.sublistView(chunk, i * inputSize, min(i * inputSize + inputSize, chunk.length));
+        inputPtr.ref
+          ..src.cast<Uint8>().asTypedList(inputSize).setAll(0, currentSlice)
+          ..size = currentSlice.length
+          ..pos = 0;
+
+        while (inputPtr.ref.pos < inputPtr.ref.size) {
+          outputPtr.ref.pos = 0;
+
+          lastRet = zstd.ZSTD_decompressStream(dctx, outputPtr, inputPtr);
+          if (zstd.ZSTD_isError(lastRet) != 0) {
+            throw NyxxException('Error decoding zstd stream: $lastRet');
+          }
+
+          // Copy contents out of buffer that will be reused.
+          result.add(outputPtr.ref.dst.cast<Uint8>().asTypedList(outputPtr.ref.pos));
+        }
+      }
+
+      output.add(result.takeBytes());
+    },
+    handleDone: (output) {
+      zstd.ZSTD_freeDCtx(dctx);
+      malloc.free(inputPtr.ref.src);
+      malloc.free(inputPtr);
+      malloc.free(outputPtr.ref.dst);
+      malloc.free(outputPtr);
+      output.close();
+    },
+  ));
+}

--- a/lib/src/gateway/decompress_zstd_stub.dart
+++ b/lib/src/gateway/decompress_zstd_stub.dart
@@ -1,0 +1,3 @@
+Stream<dynamic> decompressZStdTransport(Stream<List<int>> raw) {
+  throw UnsupportedError('ZStd decompression is not supported on this platform.');
+}

--- a/lib/src/gateway/shard_runner.dart
+++ b/lib/src/gateway/shard_runner.dart
@@ -1,19 +1,18 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:ffi';
 import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:eterl/eterl.dart';
-import 'package:ffi/ffi.dart';
 import 'package:nyxx/src/api_options.dart';
 import 'package:nyxx/src/errors.dart';
 import 'package:nyxx/src/gateway/event_parser.dart';
 import 'package:nyxx/src/gateway/message.dart';
 import 'package:nyxx/src/models/gateway/event.dart';
 import 'package:nyxx/src/models/gateway/opcode.dart';
-import 'package:zstd_ffi/_zstd.dart';
+
+import 'decompress_zstd_stub.dart' if (dart.library.ffi) 'decompress_zstd_native.dart';
 
 /// An internal class that contains the logic for running a shard.
 ///
@@ -499,73 +498,6 @@ Stream<dynamic> decompressZLibTransport(Stream<List<int>> raw) {
 
     return buffer;
   });
-}
-
-Stream<dynamic> decompressZStdTransport(Stream<List<int>> raw) {
-  final library = DynamicLibrary.open(zstdLibraryName);
-  final zstd = ZStd(library);
-
-  final inputSize = zstd.ZSTD_DStreamInSize();
-  final inputPtr = malloc<ZSTD_inBuffer>();
-  inputPtr.ref.src = malloc<Uint8>(inputSize).cast<Void>();
-
-  final outputSize = zstd.ZSTD_DStreamOutSize();
-  final outputPtr = malloc<ZSTD_outBuffer>();
-  outputPtr.ref.dst = malloc<Uint8>(outputSize).cast<Void>();
-  outputPtr.ref.size = outputSize;
-
-  final dctx = zstd.ZSTD_createDCtx();
-  if (dctx == nullptr) {
-    malloc.free(inputPtr.ref.src);
-    malloc.free(inputPtr);
-    malloc.free(outputPtr.ref.dst);
-    malloc.free(outputPtr);
-
-    throw NyxxException('Unable to initialise Zstd dctx');
-  }
-  zstd.ZSTD_initDStream(dctx);
-
-  var lastRet = 0;
-
-  return raw.transform(StreamTransformer.fromHandlers(
-    handleData: (chunk, output) {
-      if (chunk is! Uint8List) {
-        chunk = Uint8List.fromList(chunk);
-      }
-
-      final result = BytesBuilder(copy: true);
-
-      for (int i = 0; i * inputSize < chunk.length; i++) {
-        final currentSlice = Uint8List.sublistView(chunk, i * inputSize, min(i * inputSize + inputSize, chunk.length));
-        inputPtr.ref
-          ..src.cast<Uint8>().asTypedList(inputSize).setAll(0, currentSlice)
-          ..size = currentSlice.length
-          ..pos = 0;
-
-        while (inputPtr.ref.pos < inputPtr.ref.size) {
-          outputPtr.ref.pos = 0;
-
-          lastRet = zstd.ZSTD_decompressStream(dctx, outputPtr, inputPtr);
-          if (zstd.ZSTD_isError(lastRet) != 0) {
-            throw NyxxException('Error decoding zstd stream: $lastRet');
-          }
-
-          // Copy contents out of buffer that will be reused.
-          result.add(outputPtr.ref.dst.cast<Uint8>().asTypedList(outputPtr.ref.pos));
-        }
-      }
-
-      output.add(result.takeBytes());
-    },
-    handleDone: (output) {
-      zstd.ZSTD_freeDCtx(dctx);
-      malloc.free(inputPtr.ref.src);
-      malloc.free(inputPtr);
-      malloc.free(outputPtr.ref.dst);
-      malloc.free(outputPtr);
-      output.close();
-    },
-  ));
 }
 
 Stream<dynamic> decompressPayloads(Stream<dynamic> raw) => raw.map((message) {


### PR DESCRIPTION
  Summary
  This PR enables the use of NyxxRest (and other core components) on the web platform. Previously, a direct import of dart:ffi in api_options.dart caused the web compiler to crash, even for users only
  intending to use the REST client without Gateway functionality.

  Technical Details
  The implementation follows the recommended pattern for platform-specific dependencies in Dart:

   1. FFI Abstraction Layer:
       * Created lib/src/ffi_stub.dart: Defines a stub DynamicLibrary class and zstdLibraryName constant that throw UnsupportedError on non-native platforms.
       * Created lib/src/ffi_real.dart: A native-only wrapper that exports the actual dart:ffi and defines the platform-specific zstdLibraryName.
       * Updated lib/src/api_options.dart: Uses a conditional import to swap between the stub and the real FFI implementation based on dart.library.ffi.

   2. Modularized Gateway Decompression:
       * Moved the native ZStd decompression logic from shard_runner.dart into lib/src/gateway/decompress_zstd_native.dart.
       * Added lib/src/gateway/decompress_zstd_stub.dart for web compatibility.
       * Refactored ShardRunner to use conditional imports for ZStd decompression, removing all direct dependencies on dart:ffi and package:ffi from the main gateway logic.

  Impact
   * Web Users: Can now successfully compile and use NyxxRest and NyxxOAuth2.
   * Native Users: No change in behavior; ZStd decompression remains functional on supported platforms (Windows, macOS, Linux).
   * Gateway on Web: Gateway usage on the web will now gracefully fail with an UnsupportedError only if ZStd compression is explicitly attempted, rather than failing at compile-time for all users.

  ---

  Type of change
   - [x] Bug fix (non-breaking change which fixes an issue)
   - [x] New feature (non-breaking change which adds functionality)

  ---

  Checklist:
   - [x] Ran dart analyze and fixed all issues
   - [x] Ran dart format and fixed all issues
   - [x] I have made corresponding changes to the documentation
   - [x] The changes follow the existing architecture and naming conventions of the project.

  ---