### PR TITLE
Fix 6.9.0+1 release

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -2,7 +2,7 @@ name: Create release
 
 on:
   workflow_run:
-    workflows: [ Test ]
+    workflows: [Test]
     types:
       - completed
     branches:
@@ -49,6 +49,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Install dart
+        uses: dart-lang/setup-dart@v1
+
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pubspec-${{ hashFiles('**/pubspec.yaml') }}
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Dry run publish
+        run: dart pub publish --dry-run
 
       - name: Create release
         uses: softprops/action-gh-release@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.9.0+1
+__30.05.2026__
+
+- docs: Update references to documentation to point to https://nyxx.org
+
 ## 6.9.0
 __05.02.2026__
 - feat: Implement flags for attachments and media items and add new fields.


### PR DESCRIPTION
Fixes the issue preventing 6.9.0+1 from being released.

Also updates the workflows so that we don't end up with releases being created on GitHub but not on pub.dev.